### PR TITLE
Scaffold React dashboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ The dashboard layout is composed of three columns:
 
 The code is scaffolded with Vite and is intended to be modular and extensible.
 
+### Mock Content Generation
+
+The `generateContent()` utility returns random placeholder text after a short delay.
+It powers the "+ Add Block" button in the workspace.
+

--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ The code is scaffolded with Vite and is intended to be modular and extensible.
 ### Mock Content Generation
 
 The `generateContent()` utility returns random placeholder text after a short delay.
-It powers the "+ Add Block" button in the workspace.
+It powers the "+ Add Block" button in the workspace, which uses the reusable
+`Button` component from `@/components/ui/button`.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# rallygrid
-testing space for RallyGrid
+# RallyGrid
+
+A taste-aligned AI canvas for founders and creatives. This project uses React, Tailwind CSS and shadcn/ui.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+The dashboard layout is composed of three columns:
+
+1. **Left** – Navigation and style bible modules
+2. **Center** – Workspace with editable blocks and AI output
+3. **Right** – Saved insights and tags panel
+
+The code is scaffolded with Vite and is intended to be modular and extensible.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RallyGrid</title>
+    <script type="module" src="/src/main.tsx"></script>
+  </head>
+  <body class="min-h-screen bg-gray-50">
+    <div id="root"></div>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "rallygrid",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "shadcn-ui": "^0.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.27",
+    "@types/react-dom": "^18.0.10",
+    "@vitejs/plugin-react": "^3.0.0",
+    "autoprefixer": "^10.4.13",
+    "postcss": "^8.4.16",
+    "tailwindcss": "^3.2.4",
+    "typescript": "^4.9.3",
+    "vite": "^4.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,13 @@
+import Dashboard from './components/Dashboard'
+import Workspace from './components/Workspace'
+
+function App() {
+  return (
+    <Dashboard>
+      <Workspace />
+    </Dashboard>
+  )
+}
+
+export default App
+

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,22 @@
+import { FC, PropsWithChildren } from 'react'
+import LeftPanel from './LeftPanel'
+import RightPanel from './RightPanel'
+
+const Dashboard: FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <div className="grid grid-cols-12 min-h-screen">
+      <div className="col-span-2 border-r bg-white">
+        <LeftPanel />
+      </div>
+      <main className="col-span-8 overflow-y-auto">
+        {children}
+      </main>
+      <div className="col-span-2 border-l bg-white">
+        <RightPanel />
+      </div>
+    </div>
+  )
+}
+
+export default Dashboard
+

--- a/src/components/LeftPanel.tsx
+++ b/src/components/LeftPanel.tsx
@@ -1,0 +1,26 @@
+import { FC } from 'react'
+
+const LeftPanel: FC = () => {
+  return (
+    <aside className="p-4 space-y-4">
+      <nav>
+        <ul className="space-y-2">
+          <li className="font-semibold">Home</li>
+          <li>Projects</li>
+          <li>Settings</li>
+        </ul>
+      </nav>
+      <div>
+        <h2 className="font-bold mb-2">Style Bible</h2>
+        <div className="space-y-2 text-sm text-gray-600">
+          <p>Typography</p>
+          <p>Colors</p>
+          <p>Components</p>
+        </div>
+      </div>
+    </aside>
+  )
+}
+
+export default LeftPanel
+

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,0 +1,23 @@
+import { FC } from 'react'
+
+const RightPanel: FC = () => {
+  return (
+    <aside className="p-4 space-y-4">
+      <div>
+        <h2 className="font-bold mb-2">Saved Insights</h2>
+        <ul className="space-y-1 text-sm text-gray-700">
+          <li>No insights yet</li>
+        </ul>
+      </div>
+      <div>
+        <h2 className="font-bold mb-2">Tags</h2>
+        <div className="flex flex-wrap gap-2">
+          <span className="px-2 py-1 text-xs bg-gray-200 rounded">example</span>
+        </div>
+      </div>
+    </aside>
+  )
+}
+
+export default RightPanel
+

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -1,7 +1,13 @@
 import { FC, useState } from 'react'
+import generateContent from '../utils/generateContent'
 
 const Workspace: FC = () => {
   const [blocks, setBlocks] = useState<string[]>(['Editable Block'])
+
+  const addBlock = async () => {
+    const content = await generateContent()
+    setBlocks([...blocks, content])
+  }
 
   return (
     <div className="p-4 space-y-3">
@@ -19,7 +25,7 @@ const Workspace: FC = () => {
       ))}
       <button
         className="px-3 py-1 text-sm border rounded-md"
-        onClick={() => setBlocks([...blocks, ''])}
+        onClick={addBlock}
       >
         + Add Block
       </button>

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from 'react'
 import generateContent from '../utils/generateContent'
+import { Button } from '@/components/ui/button'
 
 const Workspace: FC = () => {
   const [blocks, setBlocks] = useState<string[]>(['Editable Block'])
@@ -23,12 +24,7 @@ const Workspace: FC = () => {
           }}
         />
       ))}
-      <button
-        className="px-3 py-1 text-sm border rounded-md"
-        onClick={addBlock}
-      >
-        + Add Block
-      </button>
+      <Button onClick={addBlock}>+ Add Block</Button>
     </div>
   )
 }

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -1,0 +1,31 @@
+import { FC, useState } from 'react'
+
+const Workspace: FC = () => {
+  const [blocks, setBlocks] = useState<string[]>(['Editable Block'])
+
+  return (
+    <div className="p-4 space-y-3">
+      {blocks.map((block, idx) => (
+        <textarea
+          key={idx}
+          className="w-full p-2 border rounded-md focus:outline-none focus:ring"
+          value={block}
+          onChange={e => {
+            const next = [...blocks]
+            next[idx] = e.target.value
+            setBlocks(next)
+          }}
+        />
+      ))}
+      <button
+        className="px-3 py-1 text-sm border rounded-md"
+        onClick={() => setBlocks([...blocks, ''])}
+      >
+        + Add Block
+      </button>
+    </div>
+  )
+}
+
+export default Workspace
+

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,12 @@
+import { FC, ButtonHTMLAttributes } from 'react'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const Button: FC<ButtonProps> = ({ className = '', ...props }) => (
+  <button
+    className={`px-3 py-1 text-sm border rounded-md ${className}`}
+    {...props}
+  />
+)
+
+export { Button }

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/src/utils/generateContent.ts
+++ b/src/utils/generateContent.ts
@@ -1,0 +1,10 @@
+export default async function generateContent(): Promise<string> {
+  const placeholders = [
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.',
+    'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum.',
+  ];
+  const random = placeholders[Math.floor(Math.random() * placeholders.length)];
+  return new Promise(resolve => setTimeout(() => resolve(random), 500));
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{"path": "./tsconfig.node.json"}]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold a React+Vite project skeleton with Tailwind and shadcn/ui
- add a basic dashboard layout with left, center and right panels
- include editable blocks in the workspace
- document development steps

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'react/jsx-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_685589e8f7708320a9b662004915caf7